### PR TITLE
added missing attribute to __repr__

### DIFF
--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -166,6 +166,7 @@ class WeightWindows(IDManagerMixin):
         string += '{: <16}=\t{}\n'.format('\tMesh', self.mesh)
         string += '{: <16}=\t{}\n'.format('\tParticle Type', self._particle_type)
         string += '{: <16}=\t{}\n'.format('\tEnergy Bounds', self._energy_bounds)
+        string += '{: <16}=\t{}\n'.format('\tMax lower bound ratio', self.max_lower_bound_ratio)
         string += '{: <16}=\t{}\n'.format('\tLower WW Bounds', self._lower_ww_bounds)
         string += '{: <16}=\t{}\n'.format('\tUpper WW Bounds', self._upper_ww_bounds)
         string += '{: <16}=\t{}\n'.format('\tSurvival Ratio', self._survival_ratio)


### PR DESCRIPTION
@pshriwise while looking through and testing your [PR](https://github.com/openmc-dev/openmc/pull/2609) I noticed the __repr__ was missing one of the attributes. I stuck in a line for your consideration. Sorry I couldn't see how to do this on the PR so I've made this PR to your branch